### PR TITLE
Update ipython_notebook_toc.js

### DIFF
--- a/ipython_notebook_toc.js
+++ b/ipython_notebook_toc.js
@@ -44,7 +44,7 @@ function createTOC(){
 	    if (this.id==''){this.id = this.innerHTML.replace(/ /g,"-")}
 	    var anchor = this.id;
         
-	    toc += '<li><a href="#' + escape(anchor) + '">'
+	    toc += '<li><a href="#' + encodeURIComponent(anchor) + '">'
 		+ romanize(levels[openLevel].toString()) + '. ' + titleText
 		+ '</a></li>';
         


### PR DESCRIPTION
use encodeURIComponent instead of escape

escape is deprecated,should use encodeURIComponent.

```js
encodeURIComponent('你好') // '%E4%BD%A0%E5%A5%BD' 
escape('你好')// '%u4F60%u597D' 
```

when use escape, the href not work